### PR TITLE
Remove dependency on Test::Flatten

### DIFF
--- a/META.json
+++ b/META.json
@@ -29,7 +29,6 @@
       "build" : {
          "requires" : {
             "Test::Fake::HTTPD" : "0.03",
-            "Test::Flatten" : "0.09",
             "Test::More" : "0.98",
             "Test::SharedFork" : "0.2"
          }

--- a/cpanfile
+++ b/cpanfile
@@ -7,7 +7,6 @@ requires 'perl', '5.008001';
 
 on build => sub {
     requires 'Test::Fake::HTTPD', '0.03';
-    requires 'Test::Flatten', '0.09';
     requires 'Test::More', '0.98';
     requires 'Test::SharedFork', '0.2';
 };

--- a/t/02_send.t
+++ b/t/02_send.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
-use Test::Flatten;
 use Test::SharedFork;
 use Test::Fake::HTTPD;
 use JSON;

--- a/t/04_build_request.t
+++ b/t/04_build_request.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
-use Test::Flatten;
 use Test::SharedFork;
 use Test::Fake::HTTPD;
 use JSON;


### PR DESCRIPTION
Test::Flatten does not install anymore on perl 5.24 and it appears that
WWW::Google::Cloud::Messaging installs just fine without it.
See https://github.com/xaicron/p5-Test-Flatten/issues/5