### PR TITLE
Fixed test for JSON::XS 4.0

### DIFF
--- a/t/02_send.t
+++ b/t/02_send.t
@@ -22,7 +22,7 @@ sub get_request_data {
 
 sub create_response {
     my ($code, $data, $headers) = @_;
-    my $content = eval { encode_json $data } || $data;
+    my $content = ref $data ? encode_json($data) : $data;
     return [$code => [
         'Content-Length' => length($content),
         'Content-Type'   => 'application/json; charset=UTF-8',


### PR DESCRIPTION
Hi. We're upgrading our servers from RHEL6 to RHEL8 and I had to reinstall WWW::Google::Cloud::Messaging. I ran into the same issue as here:

https://github.com/xaicron/p5-WWW-FCM-HTTP/issues/4

This pull request applies the same patch to this module.

Thanks!